### PR TITLE
feat: Support both binary and multipart uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ The flows can be enabled using the following environments variables:
 
 | Environment variable       | Default        | Description                                                                                                   |
 |----------------------------|----------------|---------------------------------------------------------------------------------------------------------------|
-| FILE_UPLOADING_URL         |                | File uploading url, it expects handling a multipart/form-data                                                 |
+| FILE_UPLOADING_URL         |                | Url of the file uploading endpoint. The endpoint should handle uploads in `multipart/form-data` or in binary                                                |
+| FILE_UPLOADING_FORMAT      |    `form`     | Expected data uploading format: `binary` or `form`                                                 |
 | TRANSCRIPTION_FETCHING_URL |                | Transcription fetching url                                                                                    |
 | WPS_CONNECTION_STRING      |                | Connection string for an Azure Web PubSub instance which can be used to send transcription processing updates |
-| WPS_HUB_NAME               | transcriptions | Azure Web PubSub Hub name on which processing updates will be sent                                            |
+| WPS_HUB_NAME               | `transcriptions` | Azure Web PubSub Hub name on which processing updates will be sent                                            |

--- a/api/files/index.ts
+++ b/api/files/index.ts
@@ -1,6 +1,19 @@
 import { Context, HttpRequest, HttpResponse } from "@azure/functions";
+import { getBoundary, parse } from 'parse-multipart-data';
 
-const fileUploadingUrl = process.env.FILE_UPLOADING_URL;
+const {FILE_UPLOADING_URL, FILE_UPLOADING_FORMAT} = process.env;
+
+// Data formats
+const binary = 'binary';
+const form = 'form';
+const supportedUploadFormats = [binary, form];
+
+const fileUploadingUrl = FILE_UPLOADING_URL;
+let fileUploadingFormat = FILE_UPLOADING_FORMAT;
+
+if (!supportedUploadFormats.includes(fileUploadingFormat)) {
+    fileUploadingFormat = form;
+}
 
 export default async function (context: Context, req: HttpRequest): Promise<HttpResponse> {
     try {
@@ -8,11 +21,23 @@ export default async function (context: Context, req: HttpRequest): Promise<Http
             throw new Error('Missing environment variable FILE_UPLOADING_URL');
         }
 
+        const originalContentType = req.headers['content-type'];
+        let contentType = originalContentType;
+        let body = req.bufferBody;
+
+        if (fileUploadingFormat === binary && originalContentType.includes('form-data')) {
+            const boundary = getBoundary(originalContentType);
+            const [file] = parse(req.bufferBody, boundary);
+
+            body = file.data;
+            contentType = file.type;
+        }
+
         const response = await fetch(fileUploadingUrl, {
             method: 'POST',
-            body: req.bufferBody,
+            body,
             headers: {
-                'Content-Type': req.headers['content-type'],
+                'Content-Type': contentType,
             },
         });
 

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "api",
       "version": "1.0.0",
+      "dependencies": {
+        "parse-multipart-data": "^1.5.0"
+      },
       "devDependencies": {
         "@azure/functions": "^3.5.1",
         "@azure/web-pubsub": "^1.1.1",
@@ -369,6 +372,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/parse-multipart-data": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/parse-multipart-data/-/parse-multipart-data-1.5.0.tgz",
+      "integrity": "sha512-ck5zaMF0ydjGfejNMnlo5YU2oJ+pT+80Jb1y4ybanT27j+zbVP/jkYmCrUGsEln0Ox/hZmuvgy8Ra7AxbXP2Mw=="
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -733,6 +741,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "parse-multipart-data": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/parse-multipart-data/-/parse-multipart-data-1.5.0.tgz",
+      "integrity": "sha512-ck5zaMF0ydjGfejNMnlo5YU2oJ+pT+80Jb1y4ybanT27j+zbVP/jkYmCrUGsEln0Ox/hZmuvgy8Ra7AxbXP2Mw=="
     },
     "safe-buffer": {
       "version": "5.2.1",

--- a/api/package.json
+++ b/api/package.json
@@ -14,5 +14,8 @@
     "@azure/web-pubsub": "^1.1.1",
     "@types/node": "^18.x",
     "typescript": "^4.0.0"
+  },
+  "dependencies": {
+    "parse-multipart-data": "^1.5.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.5.2",
-        "@types/node": "^16.18.16",
+        "@types/node": "^18.x",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
         "react": "^18.2.0",
@@ -4945,9 +4945,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.18.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.16.tgz",
-      "integrity": "sha512-ZOzvDRWp8dCVBmgnkIqYCArgdFOO9YzocZp8Ra25N/RStKiWvMOXHMz+GjSeVNe5TstaTmTWPucGJkDw0XXJWA=="
+      "version": "18.16.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
+      "integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -23843,9 +23843,9 @@
       }
     },
     "@types/node": {
-      "version": "16.18.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.16.tgz",
-      "integrity": "sha512-ZOzvDRWp8dCVBmgnkIqYCArgdFOO9YzocZp8Ra25N/RStKiWvMOXHMz+GjSeVNe5TstaTmTWPucGJkDw0XXJWA=="
+      "version": "18.16.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
+      "integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g=="
     },
     "@types/parse-json": {
       "version": "4.0.0",


### PR DESCRIPTION
Add a new environment variable `FILE_UPLOADING_FORMAT` to allow specifying the file upload format expected by the upload endpoint:

- `form` (default): multipart/form-data uploads
- `binary`: send file contents directly in the POST request body

noissue